### PR TITLE
Add file existence check in schema generation test

### DIFF
--- a/formation-hibernate/src/test/java/fr/insee/formation/hibernate/GenerationScriptCreateTest.java
+++ b/formation-hibernate/src/test/java/fr/insee/formation/hibernate/GenerationScriptCreateTest.java
@@ -5,6 +5,9 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import fr.insee.formation.hibernate.config.AbstractTest;
 
@@ -15,15 +18,18 @@ import fr.insee.formation.hibernate.config.AbstractTest;
 @ActiveProfiles("test")
 public class GenerationScriptCreateTest extends AbstractTest {
 
-	@Test
-	public void testGenerationScriptCreate() {
+       @Test
+       public void testGenerationScriptCreate() throws Exception {
 
-		/**
-		 * Lancer ce test et rafraîchissez au niveau du projet. Un fichier create.sql
-		 * doit apparaître à la racine à côté du pom.xml
-		 */
-		org.junit.Assert.assertTrue(true);
+               /*
+                * Lancer ce test et rafraîchissez au niveau du projet. Un fichier create.sql
+                * doit apparaître à la racine à côté du pom.xml
+                */
+               Path createScript = Paths.get("create.sql");
+               org.junit.Assert.assertTrue(Files.exists(createScript));
+               // Nettoyage du projet : suppression du script généré
+               Files.deleteIfExists(createScript);
 
-	}
+       }
 
 }


### PR DESCRIPTION
## Summary
- verify that `create.sql` is generated in `GenerationScriptCreateTest`
- remove the file after the assertion to keep project clean

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6887656a48dc832aa8c3727571d3ae70